### PR TITLE
feat: mat to buffer (#3)

### DIFF
--- a/cpp/FOCV_Function.cpp
+++ b/cpp/FOCV_Function.cpp
@@ -1266,6 +1266,13 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
             auto id = FOCV_Storage::save(rect);
             return FOCV_JsiObject::wrap(runtime, "rotated_rect", id);
         } break;
+        case hashString("convertTo", 9): {
+            auto src = args.asMatPtr(1);
+            auto dst = args.asMatPtr(2);
+            auto rtype = args.asNumber(3);
+            
+            (*src).convertTo(*dst, rtype);
+        } break;
     }
     
     return value;

--- a/docs/pages/apidetails.md
+++ b/docs/pages/apidetails.md
@@ -10,7 +10,8 @@ createObject(
   type: ObjectType.Mat,
   rows: number,
   cols: number,
-  dataType: DataTypes
+  dataType: DataTypes,
+  data?: number[]
 ): Mat;
 createObject(type: ObjectType.MatVector): MatVector;
 createObject(type: ObjectType.Point, x: number, y: number): Point;
@@ -123,6 +124,21 @@ Creates an object of type Mat based on image in Base64.
 
 ```js
 base64ToMat(data: string): Mat;
+```
+
+### Mat to Buffer
+Convert Mat object to Uint8Array or Float32Array based on value of parameter and returns with number of cols, rows and channels.
+
+```js
+matToBuffer(
+  mat: Mat,
+  type: 'uint8'
+): { cols: number; rows: number; channels: number; buffer: Uint8Array };
+
+matToBuffer(
+  mat: Mat,
+  type: 'float32'
+): { cols: number; rows: number; channels: number; buffer: Float32Array };
 ```
 
 ## Functions

--- a/docs/pages/availablefunctions.md
+++ b/docs/pages/availablefunctions.md
@@ -249,7 +249,7 @@ invoke(name: 'completeSymm', m: MatVector | Mat, lowerToUpper: boolean): void;
 
 ### convertFp16
 
-Converts an array to half precision floating number.\
+Converts an array to half precision floating number.
 
 - src input array
 - dst output array
@@ -283,6 +283,18 @@ invoke(
   alpha: number,
   beta: number
 ): void;
+```
+
+### convertTo
+
+Converts an array to another data type with optional scaling.
+
+- src input array
+- dst output array of the same type as src
+- rtype  desired output matrix type or, rather, the depth since the number of channels are the same as the input has; if rtype is negative, the output matrix will have the same type as the input.
+
+```js
+invoke(name: 'convertTo', src: Mat, dst: Mat, rtype: DataTypes): void;
 ```
 
 ### copyMakeBorder

--- a/src/functions/Core.ts
+++ b/src/functions/Core.ts
@@ -903,4 +903,13 @@ export type Core = {
    * @param dst output array. It has the same number of cols and depth as the src, and the sum of rows of the src. same depth
    */
   invoke(name: 'vconcat', src: MatVector, dst: Mat): void;
+
+  /**
+   * Converts an array to another data type with optional scaling.
+   * @param name Function name.
+   * @param src input array.
+   * @param dst output array of the same type as src
+   * @param rtype  desired output matrix type or, rather, the depth since the number of channels are the same as the input has; if rtype is negative, the output matrix will have the same type as the input.
+   */
+  invoke(name: 'convertTo', src: Mat, dst: Mat, rtype: DataTypes): void;
 };

--- a/src/utils/UtilsFunctions.ts
+++ b/src/utils/UtilsFunctions.ts
@@ -4,4 +4,12 @@ export type UtilsFunctions = {
   clearBuffers(): void;
   frameBufferToMat(rows: number, cols: number, input: Uint8Array): Mat;
   base64ToMat(data: string): Mat;
+  matToBuffer(
+    mat: Mat,
+    type: 'uint8'
+  ): { cols: number; rows: number; channels: number; buffer: Uint8Array };
+  matToBuffer(
+    mat: Mat,
+    type: 'float32'
+  ): { cols: number; rows: number; channels: number; buffer: Float32Array };
 };


### PR DESCRIPTION
- `matToBuffer` function with possibility to return data as `UInt8Array` or `Float32Array`. 
- Support for `convertTo` OpenCV method from Mat object.
- Documentation update. 


I need to add template here :)