### PR TITLE
feat: point vector of vectors with changes in contours functions

### DIFF
--- a/cpp/FOCV_Function.cpp
+++ b/cpp/FOCV_Function.cpp
@@ -1183,8 +1183,10 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
             
             if(args.isMat(1)) {
                 rect = cv::boundingRect(*args.asMatPtr(1));
-            } else {
+            } else if(args.isMatVector(1)) {
                 rect = cv::boundingRect(*args.asMatVectorPtr(1));
+            } else {
+                rect = cv::boundingRect(*args.asPointVectorPtr(1));
             }
             
             std::string id = FOCV_Storage::save(rect);
@@ -1208,10 +1210,15 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
             value.setProperty(runtime, "value", jsi::Value(result));
         } break;
         case hashString("contourArea", 11): {
-            auto src = args.asMatPtr(1);
             auto oriented = args.asBool(2);
             
-            value.setProperty(runtime, "value", contourArea(*src, oriented));
+            if(args.isMat(1)) {
+                auto src = args.asMatPtr(1);
+                value.setProperty(runtime, "value", contourArea(*src, oriented));
+            } else {
+                auto src = args.asPointVectorPtr(1);
+                value.setProperty(runtime, "value", contourArea(*src, oriented));
+            }
         } break;
         case hashString("convexHull", 10): {
             auto src = args.asMatPtr(1);
@@ -1228,11 +1235,16 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
         } break;
         case hashString("findContours", 12): {
             auto src = args.asMatPtr(1);
-            auto dst = args.asMatVectorPtr(2);
             auto mode = args.asNumber(3);
             auto method = args.asNumber(4);
-
-            cv::findContours(*src, *dst, mode, method);
+            
+            if(args.isMatVector(2)) {
+                auto dst = args.asMatVectorPtr(2);
+                cv::findContours(*src, *dst, mode, method);
+            } else {
+                auto dst = args.asPointVectorOfVectorsPtr(2);
+                cv::findContours(*src, *dst, mode, method);
+            }
         } break;
         case hashString("fitLine", 7): {
             auto points = args.asMatPtr(1);

--- a/cpp/FOCV_FunctionArguments.cpp
+++ b/cpp/FOCV_FunctionArguments.cpp
@@ -43,6 +43,10 @@ std::shared_ptr<std::vector<cv::Point>> FOCV_FunctionArguments::asPointVectorPtr
     return FOCV_Storage::get<std::vector<cv::Point>>(FOCV_JsiObject::id_from_wrap(*this->runtime, arguments[index]));
 }
 
+std::shared_ptr<std::vector<std::vector<cv::Point>>> FOCV_FunctionArguments::asPointVectorOfVectorsPtr(int index) {
+    return FOCV_Storage::get<std::vector<std::vector<cv::Point>>>(FOCV_JsiObject::id_from_wrap(*this->runtime, arguments[index]));
+}
+
 std::shared_ptr<cv::Rect> FOCV_FunctionArguments::asRectPtr(int index) {
     return FOCV_Storage::get<cv::Rect>(FOCV_JsiObject::id_from_wrap(*this->runtime, arguments[index]));
 }
@@ -81,4 +85,8 @@ bool FOCV_FunctionArguments::isObject(int index) {
 
 bool FOCV_FunctionArguments::isMat(int index) {
     return FOCV_JsiObject::type_from_wrap(*this->runtime, arguments[index]) == "mat";
+}
+
+bool FOCV_FunctionArguments::isMatVector(int index) {
+    return FOCV_JsiObject::type_from_wrap(*this->runtime, arguments[index]) == "mat_vector";
 }

--- a/cpp/FOCV_FunctionArguments.hpp
+++ b/cpp/FOCV_FunctionArguments.hpp
@@ -43,6 +43,7 @@ public:
     std::shared_ptr<std::vector<cv::Mat>> asMatVectorPtr(int index);
     std::shared_ptr<cv::Point> asPointPtr(int index);
     std::shared_ptr<std::vector<cv::Point>> asPointVectorPtr(int index);
+    std::shared_ptr<std::vector<std::vector<cv::Point>>> asPointVectorOfVectorsPtr(int index);
     std::shared_ptr<cv::Rect> asRectPtr(int index);
     std::shared_ptr<std::vector<cv::Rect>> asRectVectorPtr(int index);
     std::shared_ptr<cv::Size> asSizePtr(int index);
@@ -54,6 +55,7 @@ public:
     bool isString(int index);
     bool isObject(int index);
     bool isMat(int index);
+    bool isMatVector(int index);
 };
 
 #endif /* FOCV_FunctionArguments_hpp */

--- a/cpp/FOCV_Object.cpp
+++ b/cpp/FOCV_Object.cpp
@@ -88,6 +88,10 @@ jsi::Object FOCV_Object::create(jsi::Runtime& runtime, const jsi::Value* argumen
             std::vector<cv::Point> object;
             id = FOCV_Storage::save(object);
         } break;
+        case hashString("point_vector_vector", 19): {
+            std::vector<std::vector<cv::Point>> object;
+            id = FOCV_Storage::save(object);
+        } break;
         case hashString("size", 4): {
             int width = arguments[1].asNumber();
             int height = arguments[2].asNumber();
@@ -216,6 +220,28 @@ jsi::Object FOCV_Object::convertToJSI(jsi::Runtime& runtime, const jsi::Value* a
 
             value.setProperty(runtime, "array", array);
         } break;
+        case hashString("point_vector_vector", 19): {
+            auto points_vector = *FOCV_Storage::get<std::vector<std::vector<cv::Point>>>(id);
+
+            auto vectors_array = jsi::Array(runtime, points_vector.size());
+
+            for (int i = 0; i < points_vector.size(); i++) {
+                auto points = points_vector.at(i);
+                auto array = jsi::Array(runtime, points.size());
+              
+                for (int j = 0; j < points.size(); j++) {
+                    jsi::Object item(runtime);
+                    
+                    item.setProperty(runtime, "x", jsi::Value(points.at(j).x));
+                    item.setProperty(runtime, "y", jsi::Value(points.at(j).y));
+                    array.setValueAtIndex(runtime, j, item);
+                }
+                
+                vectors_array.setValueAtIndex(runtime, i, array);
+            }
+
+            value.setProperty(runtime, "array", vectors_array);
+        } break;
         case hashString("size", 4): {
             auto size = *FOCV_Storage::get<cv::Size>(id);
 
@@ -277,6 +303,12 @@ jsi::Object FOCV_Object::copyObjectFromVector(jsi::Runtime& runtime, const jsi::
             cv::Point point = array.at(index);
             createdId = FOCV_Storage::save(point);
             return FOCV_JsiObject::wrap(runtime, "point", createdId);
+        } break;
+        case hashString("point_vector_vector", 19): {
+            auto array = *FOCV_Storage::get<std::vector<std::vector<cv::Point>>>(vectorId);
+            std::vector<cv::Point> point = array.at(index);
+            createdId = FOCV_Storage::save(point);
+            return FOCV_JsiObject::wrap(runtime, "point_vector", createdId);
         } break;
     }
 

--- a/docs/pages/apidetails.md
+++ b/docs/pages/apidetails.md
@@ -16,6 +16,7 @@ createObject(
 createObject(type: ObjectType.MatVector): MatVector;
 createObject(type: ObjectType.Point, x: number, y: number): Point;
 createObject(type: ObjectType.PointVector): PointVector;
+createObject(type: ObjectType.PointVectorOfVectors): PointVectorOfVectors;
 createObject(
   type: ObjectType.Rect,
   x: number,
@@ -49,6 +50,10 @@ Copies an object from a vector to a separate object.
 ```js
 copyObjectFromVector(vector: MatVector, itemIndex: number): Mat;
 copyObjectFromVector(vector: PointVector, itemIndex: number): Point;
+copyObjectFromVector(
+  vector: PointVectorOfVectors,
+  itemIndex: number
+): PointVector;
 copyObjectFromVector(vector: RectVector, itemIndex: number): Rect;
 ```
 
@@ -76,6 +81,12 @@ toJSValue(pointVector: PointVector): {
     x: number;
     y: number;
   }[];
+};
+toJSValue(pointVector: PointVectorOfVectors): {
+  array: {
+    x: number;
+    y: number;
+  }[][];
 };
 toJSValue(rect: Rect): {
   x: number;

--- a/docs/pages/availablefunctions.md
+++ b/docs/pages/availablefunctions.md
@@ -1998,7 +1998,7 @@ Calculates the up-right bounding rectangle of a point set or non-zero pixels of 
 @returns the minimal up-right bounding rectangle for the specified point set or non-zero pixels of gray-scale image
 
 ```js
-invoke(name: 'boundingRect', array: Mat | MatVector): Rect;
+invoke(name: 'boundingRect', array: Mat | MatVector | PointVector): Rect;
 ```
 
 ### connectedComponents
@@ -2042,7 +2042,7 @@ Calculates a contour area
 ```js
 invoke(
   name: 'contourArea',
-  contour: Mat | MatVector,
+  contour: Mat | MatVector | PointVector,
   oriented?: boolean
 ): { value: number };
 ```
@@ -2082,7 +2082,7 @@ Finds contours in a binary image
 invoke(
   name: 'findContours',
   image: Mat | MatVector,
-  contours: Mat | MatVector,
+  contours: MatVector | PointVectorOfVectors,
   mode: RetrievalModes,
   method: ContourApproximationModes
 ): void;

--- a/docs/pages/usage.md
+++ b/docs/pages/usage.md
@@ -15,7 +15,7 @@ You can do this e.g. after a calculation, or after a specific step. **Remember t
 
 ## Objects
 
-The library currently supports the following OpenCV objects: **Mat, MatVector, Point, Point Vector, Rect, RectVector, Size, Scalar and RotatedRect.**
+The library currently supports the following OpenCV objects: **Mat, MatVector, Point, Point Vector, Point Vector of Vectors, Rect, RectVector, Size, Scalar and RotatedRect.**
 
 > A vector is simply an array in which individual objects are held.
 

--- a/src/functions/ImageProcessing/Shape.ts
+++ b/src/functions/ImageProcessing/Shape.ts
@@ -4,7 +4,14 @@ import type {
   RetrievalModes,
   ShapeMatchModes,
 } from '../../constants/ImageProcessing';
-import type { Mat, MatVector, Rect, RotatedRect } from '../../objects/Objects';
+import type {
+  Mat,
+  MatVector,
+  PointVector,
+  PointVectorOfVectors,
+  Rect,
+  RotatedRect,
+} from '../../objects/Objects';
 
 export type Shape = {
   /**
@@ -39,7 +46,7 @@ export type Shape = {
    * @param array Input gray-scale image or 2D point set, stored in std::vector or Mat.
    * @returns the minimal up-right bounding rectangle for the specified point set or non-zero pixels of gray-scale image
    */
-  invoke(name: 'boundingRect', array: Mat | MatVector): Rect;
+  invoke(name: 'boundingRect', array: Mat | MatVector | PointVector): Rect;
 
   /**
    * computes the connected components labeled image of boolean image
@@ -77,7 +84,7 @@ export type Shape = {
    */
   invoke(
     name: 'contourArea',
-    contour: Mat | MatVector,
+    contour: Mat | MatVector | PointVector,
     oriented?: boolean
   ): { value: number };
 
@@ -110,8 +117,8 @@ export type Shape = {
    */
   invoke(
     name: 'findContours',
-    image: Mat | MatVector,
-    contours: Mat | MatVector,
+    image: Mat,
+    contours: MatVector | PointVectorOfVectors,
     mode: RetrievalModes,
     method: ContourApproximationModes
   ): void;

--- a/src/objects/ObjectType.ts
+++ b/src/objects/ObjectType.ts
@@ -3,6 +3,7 @@ export enum ObjectType {
   MatVector = 'mat_vector',
   Point = 'point',
   PointVector = 'point_vector',
+  PointVectorOfVectors = 'point_vector_vector',
   Rect = 'rect',
   RectVector = 'rect_vector',
   Size = 'size',

--- a/src/objects/Objects.ts
+++ b/src/objects/Objects.ts
@@ -5,6 +5,10 @@ export type Mat = { id: string; type: ObjectType.Mat };
 export type MatVector = { id: string; type: ObjectType.MatVector };
 export type Point = { id: string; type: ObjectType.Point };
 export type PointVector = { id: string; type: ObjectType.PointVector };
+export type PointVectorOfVectors = {
+  id: string;
+  type: ObjectType.PointVectorOfVectors;
+};
 export type Rect = { id: string; type: ObjectType.Rect };
 export type RectVector = { id: string; type: ObjectType.RectVector };
 export type Size = { id: string; type: ObjectType.Size };
@@ -27,6 +31,7 @@ export type Objects = {
   createObject(type: ObjectType.MatVector): MatVector;
   createObject(type: ObjectType.Point, x: number, y: number): Point;
   createObject(type: ObjectType.PointVector): PointVector;
+  createObject(type: ObjectType.PointVectorOfVectors): PointVectorOfVectors;
   createObject(
     type: ObjectType.Rect,
     x: number,
@@ -70,6 +75,12 @@ export type Objects = {
       y: number;
     }[];
   };
+  toJSValue(pointVector: PointVectorOfVectors): {
+    array: {
+      x: number;
+      y: number;
+    }[][];
+  };
   toJSValue(rect: Rect): {
     x: number;
     y: number;
@@ -97,5 +108,9 @@ export type Objects = {
 
   copyObjectFromVector(vector: MatVector, itemIndex: number): Mat;
   copyObjectFromVector(vector: PointVector, itemIndex: number): Point;
+  copyObjectFromVector(
+    vector: PointVectorOfVectors,
+    itemIndex: number
+  ): PointVector;
   copyObjectFromVector(vector: RectVector, itemIndex: number): Rect;
 };


### PR DESCRIPTION
- New `PointVectorOfVectors` structure (with support for `createObject `, `toJSValue` and `copyObjectFromVector `.
- Allow this structure to works with `findContours`, `contourArea` and `boundingRect` functions.
- Documentation update.