### PR TITLE
Additional typing and features

### DIFF
--- a/cpp/FOCV_Function.cpp
+++ b/cpp/FOCV_Function.cpp
@@ -1108,6 +1108,12 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
         
         cv::medianBlur(*src, *dst, ksize);
       } break;
+      case hashString("morphologyDefaultBorderValue", 28): {
+        auto scalar = cv::morphologyDefaultBorderValue();
+        std::string id = FOCV_Storage::save(scalar);
+
+        return FOCV_JsiObject::wrap(runtime, "scalar", id);
+      } break;
       case hashString("morphologyEx", 12): {
         auto src = args.asMatPtr(1);
         auto dst = args.asMatPtr(2);

--- a/cpp/FOCV_Function.cpp
+++ b/cpp/FOCV_Function.cpp
@@ -1151,6 +1151,19 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
         
         cv::integral(*src, *dst);
       } break;
+      case hashString("Sobel", 5): {
+        auto src = args.asMatPtr(1);
+        auto dst = args.asMatPtr(2);
+        auto ddepth = args.asNumber(3);
+        auto dx = args.asNumber(4);
+        auto dy = args.asNumber(5);
+        auto ksize = args.asNumber(6);
+        auto scale = args.asNumber(7);
+        auto delta = args.asNumber(8);
+        auto borderType = args.asNumber(9);
+
+        cv::Sobel(*src, *dst, ddepth, dx, dy, ksize, scale, delta, borderType);
+      } break;
       case hashString("threshold", 9): {
         auto src = args.asMatPtr(1);
         auto dst = args.asMatPtr(2);

--- a/cpp/FOCV_Function.cpp
+++ b/cpp/FOCV_Function.cpp
@@ -1154,16 +1154,36 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
         cv::matchTemplate(*image, *templ, *result, method, *mask);
       } break;
       case hashString("approxPolyDP", 12): {
-        auto approxCurve = args.asMatPtr(2);
         auto epsilon = args.asNumber(3);
         auto closed = args.asBool(4);
-        
+
         if(args.isMat(1)) {
-          auto curve = args.asMatPtr(1);
-          cv::approxPolyDP(*curve, *approxCurve, epsilon, closed);
+            auto curve = args.asMatPtr(1);
+            if (args.isMat(2)) {
+                auto approxCurve = args.asMatPtr(2);
+                cv::approxPolyDP(*curve, *approxCurve, epsilon, closed);
+            } else {
+                auto approxCurve = args.asPointVectorPtr(2);
+                cv::approxPolyDP(*curve, *approxCurve, epsilon, closed);
+            }
+        } else if (args.isMatVector(1)) {
+            auto curve = args.asMatVectorPtr(1);
+            if (args.isMat(2)) {
+                auto approxCurve = args.asMatPtr(2);
+                cv::approxPolyDP(*curve, *approxCurve, epsilon, closed);
+            } else {
+                auto approxCurve = args.asPointVectorPtr(2);
+                cv::approxPolyDP(*curve, *approxCurve, epsilon, closed);
+            }
         } else {
-          auto curve = args.asMatVectorPtr(1);
-          cv::approxPolyDP(*curve, *approxCurve, epsilon, closed);
+            auto curve = args.asPointVectorPtr(1);
+            if (args.isMat(2)) {
+                auto approxCurve = args.asMatPtr(2);
+                cv::approxPolyDP(*curve, *approxCurve, epsilon, closed);
+            } else {
+                auto approxCurve = args.asPointVectorPtr(2);
+                cv::approxPolyDP(*curve, *approxCurve, epsilon, closed);
+            }
         }
       } break;
       case hashString("arcLength", 9): {
@@ -1173,10 +1193,14 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
           auto curve = args.asMatPtr(1);
           auto result = cv::arcLength(*curve, closed);
           value.setProperty(runtime, "value", jsi::Value(result));
+        } else if(args.isMatVector(1)) {
+            auto curve = args.asMatVectorPtr(1);
+            auto result = cv::arcLength(*curve, closed);
+            value.setProperty(runtime, "value", jsi::Value(result));
         } else {
-          auto curve = args.asMatVectorPtr(1);
-          auto result = cv::arcLength(*curve, closed);
-          value.setProperty(runtime, "value", jsi::Value(result));
+            auto curve = args.asPointVectorPtr(1);
+            auto result = cv::arcLength(*curve, closed);
+            value.setProperty(runtime, "value", jsi::Value(result));
         }
       } break;
       case hashString("boundingRect", 12): {

--- a/cpp/FOCV_Function.cpp
+++ b/cpp/FOCV_Function.cpp
@@ -1080,6 +1080,16 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
         
         return FOCV_JsiObject::wrap(runtime, "mat", id);
       } break;
+      case hashString("getStructuringElement", 21): {
+        auto shape = args.asNumber(1);
+        auto ksize = args.asSizePtr(2);
+        auto anchor = args.asPointPtr(3);
+
+        cv::Mat result = cv::getStructuringElement(shape, *ksize, *anchor);
+        std::string id = FOCV_Storage::save(result);
+
+        return FOCV_JsiObject::wrap(runtime, "mat", id);
+      } break;
       case hashString("Laplacian", 9): {
         auto src = args.asMatPtr(1);
         auto dst = args.asMatPtr(2);

--- a/docs/pages/availablefunctions.md
+++ b/docs/pages/availablefunctions.md
@@ -1793,6 +1793,23 @@ invoke(
 ): Mat;
 ```
 
+### getStructuringElement
+
+Returns a structuring element of the specified size and shape for morphological operations.
+
+- shape Element shape that could be one of MorphShapes
+- ksize Size of the structuring element.
+- anchor Anchor position within the element. The default value means that the anchor is at the center. Note that only the shape of a cross-shaped element depends on the anchor position. In other cases the anchor just regulates how much the result of the morphological operation is shifted..
+
+```js
+invoke(
+  name: 'getGaussianKernel',
+    shape: MorphShapes,
+    ksize: Size,
+    anchor: Point
+): Mat;
+```
+
 ### Laplacian
 Calculates the Laplacian of an image.
 - name Function name.

--- a/docs/pages/availablefunctions.md
+++ b/docs/pages/availablefunctions.md
@@ -1846,6 +1846,14 @@ The function smoothes an image using the median filter with the 𝚔𝚜𝚒𝚣
 invoke(name: 'medianBlur', src: Mat, dst: Mat, ksize: number): void;
 ```
 
+### morphologyDefaultBorderValue
+
+@returns "magic" border value for erosion and dilation. It is automatically transformed to Scalar::all(-DBL_MAX) for dilation.
+
+```js
+invoke(name: 'morphologyDefaultBorderValue'): Scalar;
+```
+
 ### morphologyEx
 Performs advanced morphological transformations.
 The function cv::morphologyEx can perform advanced morphological transformations using an erosion and dilation as basic operations.

--- a/docs/pages/availablefunctions.md
+++ b/docs/pages/availablefunctions.md
@@ -1940,6 +1940,36 @@ Calculates the integral of an image
 invoke(name: 'integral', src: Mat, sum: Mat): void;
 ```
 
+### Sobel
+
+Calculates the first, second, third, or mixed image derivatives using an extended Sobel operator.
+
+- name Function name.
+- src input image.
+- dst output image of the same size and the same number of channels as src .
+- ddepth output image depth, see combinations; in the case of 8-bit input images it will result in truncated derivatives.
+- dx order of the derivative x.
+- dy order of the derivative y.
+- ksize size of the extended Sobel kernel; it must be 1, 3, 5, or 7.
+- scale scale factor for the computed derivative values; by default, no scaling is applied (see getDerivKernels for details).
+- delta delta value that is added to the results prior to storing them in dst.
+- borderType Pixel extrapolation method, see BorderTypes. BORDER_WRAP is not supported.
+
+```js
+invoke(
+  name: 'Sobel',
+  src: Mat,
+  dst: Mat,
+  ddepth: number,
+  dx: number,
+  dy: number,
+  ksize: 1 | 3 | 5 | 7,
+  scale: number,
+  delta: number,
+  borderType: Exclude<BorderTypes, BorderTypes.BORDER_WRAP>
+): void;
+```
+
 ### threshold
 Applies a fixed-level threshold to each array element
 - name Function name.

--- a/docs/pages/availablefunctions.md
+++ b/docs/pages/availablefunctions.md
@@ -1971,7 +1971,7 @@ Approximates a polygonal curve(s) with the specified precision
 ```js
 invoke(
   name: 'approxPolyDP',
-  curve: Mat | MatVector,
+  curve: Mat | MatVector | PointVector,
   approxCurve: Mat,
   epsilon: number,
   closed: boolean
@@ -1987,7 +1987,7 @@ Calculates a contour perimeter or a curve length.
 ```js
 invoke(
   name: 'arcLength',
-  curve: Mat | MatVector,
+  curve: Mat | MatVector | PointVector,
   closed: boolean
 ): { value: number };
 ```

--- a/src/constants/ImageProcessing.ts
+++ b/src/constants/ImageProcessing.ts
@@ -67,9 +67,9 @@ export enum LineSegmentDetectorModes {
 }
 
 export enum MorphShapes {
-  MORPH_RECT = 'MORPH_RECT',
-  MORPH_CROSS = 'MORPH_CROSS',
-  MORPH_ELLIPSE = 'MORPH_ELLIPSE',
+  MORPH_RECT = 0,
+  MORPH_CROSS = 1,
+  MORPH_ELLIPSE = 2,
 }
 
 export enum MorphTypes {

--- a/src/functions/ImageProcessing/ImageFiltering.ts
+++ b/src/functions/ImageProcessing/ImageFiltering.ts
@@ -1,6 +1,6 @@
 import type { BorderTypes } from '../../constants/Core';
 import type { DataTypes } from '../../constants/DataTypes';
-import type { MorphTypes } from '../../constants/ImageProcessing';
+import type { MorphShapes, MorphTypes } from '../../constants/ImageProcessing';
 import type { Mat, Point, Scalar, Size } from '../../objects/Objects';
 
 export type ImageFiltering = {
@@ -190,6 +190,19 @@ export type ImageFiltering = {
     ksize: number,
     sigma: number,
     ktype: DataTypes.CV_32F | DataTypes.CV_64F
+  ): Mat;
+
+  /**
+   * Returns a structuring element of the specified size and shape for morphological operations.
+   * @param shape Element shape that could be one of MorphShapes
+   * @param ksize Size of the structuring element.
+   * @param anchor Anchor position within the element. The default value means that the anchor is at the center. Note that only the shape of a cross-shaped element depends on the anchor position. In other cases the anchor just regulates how much the result of the morphological operation is shifted.
+   */
+  invoke(
+    name: 'getStructuringElement',
+    shape: MorphShapes,
+    ksize: Size,
+    anchor: Point
   ): Mat;
 
   /**

--- a/src/functions/ImageProcessing/ImageFiltering.ts
+++ b/src/functions/ImageProcessing/ImageFiltering.ts
@@ -238,6 +238,11 @@ export type ImageFiltering = {
   invoke(name: 'medianBlur', src: Mat, dst: Mat, ksize: number): void;
 
   /**
+   * returns "magic" border value for erosion and dilation. It is automatically transformed to Scalar::all(-DBL_MAX) for dilation.
+   */
+  invoke(name: 'morphologyDefaultBorderValue'): Scalar;
+
+  /**
    * Performs advanced morphological transformations.
    * The function cv::morphologyEx can perform advanced morphological transformations using an erosion and dilation as basic operations.
    * Any of the operations can be done in-place. In case of multi-channel images, each channel is processed independently.

--- a/src/functions/ImageProcessing/ImageFiltering.ts
+++ b/src/functions/ImageProcessing/ImageFiltering.ts
@@ -267,4 +267,30 @@ export type ImageFiltering = {
     borderType: BorderTypes,
     borderValue: Scalar
   ): void;
+
+  /**
+   * Calculates the first, second, third, or mixed image derivatives using an extended Sobel operator.
+   * @param name Function name.
+   * @param src input image.
+   * @param dst output image of the same size and the same number of channels as src .
+   * @param ddepth output image depth, see combinations; in the case of 8-bit input images it will result in truncated derivatives.
+   * @param dx order of the derivative x.
+   * @param dy order of the derivative y.
+   * @param ksize size of the extended Sobel kernel; it must be 1, 3, 5, or 7.
+   * @param scale scale factor for the computed derivative values; by default, no scaling is applied (see getDerivKernels for details).
+   * @param delta delta value that is added to the results prior to storing them in dst.
+   * @param borderType Pixel extrapolation method, see BorderTypes. BORDER_WRAP is not supported.
+   */
+  invoke(
+    name: 'Sobel',
+    src: Mat,
+    dst: Mat,
+    ddepth: number,
+    dx: number,
+    dy: number,
+    ksize: 1 | 3 | 5 | 7,
+    scale: number,
+    delta: number,
+    borderType: Exclude<BorderTypes, BorderTypes.BORDER_WRAP>
+  ): void;
 };

--- a/src/functions/ImageProcessing/Shape.ts
+++ b/src/functions/ImageProcessing/Shape.ts
@@ -23,8 +23,8 @@ export type Shape = {
    */
   invoke(
     name: 'approxPolyDP',
-    curve: Mat | MatVector,
-    approxCurve: Mat,
+    curve: Mat | MatVector | PointVector,
+    approxCurve: Mat | PointVector,
     epsilon: number,
     closed: boolean
   ): void;
@@ -37,7 +37,7 @@ export type Shape = {
    */
   invoke(
     name: 'arcLength',
-    curve: Mat | MatVector,
+    curve: Mat | MatVector | PointVector,
     closed: boolean
   ): { value: number };
 


### PR DESCRIPTION
This adds support to pass the new pointvector type to arcLength and approxPolyDP, fixes the MorphShapes enum, and adds support for 3 new functions (getStructuringElement, morphologyDefaultBorderValue and Sobel)