### PR TITLE
Fix: Remove native_modules.gradle from example settings.gradle

### DIFF
--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -2,6 +2,5 @@ pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
 extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 rootProject.name = 'fastopencv.example'
-apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')


### PR DESCRIPTION
### Summary

Removes the line from `example/android/settings.gradle` that references `native_modules.gradle`.  
This file no longer exists in React Native 0.79+ projects and its inclusion breaks the build.

### Details

- **Removed line:**  
  ```gradle
  apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
  ```
- With React Native 0.79+, the file `native_modules.gradle` is not present in the default template.
- See [React Native 0.79.6 settings.gradle template](https://raw.githubusercontent.com/react-native-community/rn-diff-purge/release/0.79.6/RnDiffApp/android/settings.gradle) for reference.
- Fixes [#100](https://github.com/lukaszkurantdev/react-native-fast-opencv/issues/100).

### Motivation

Build fails with the following error:
```
A problem occurred evaluating settings 'fastopencv.example'.
> Could not read script '../example/node_modules/@react-native-community/cli-platform-android/native_modules.gradle' as it does not exist.
```
Removing the line resolves the issue and aligns with upstream React Native template.

### Test Plan

- Verified that the example app builds successfully after removing the line on RN 0.79+