### PR TITLE
Raise minSdkVersion to 26 for Android camera realtime detection compatibility

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         buildToolsVersion = "35.0.0"
-        minSdkVersion = 24
+        minSdkVersion = 26
         compileSdkVersion = 35
         targetSdkVersion = 35
         ndkVersion = "27.1.12297006"


### PR DESCRIPTION

This PR updates the minSdkVersion in example/android/build.gradle from 24 to 26. This change resolves the issue where camera realtime detection fails on Android devices below API 26 due to the requirement for HardwareBuffers ([see issue #102](https://github.com/lukaszkurantdev/react-native-fast-opencv/issues/102)).
Error encountered:

Code
Frame Processor Error: Cannot get Platform Buffer - getNativeBuffer() requires HardwareBuffers, which are only available on Android API 26 or above. Set your app's minSdk version to 26 and try again., js engine: VisionCamera
Fixes: #102

