### PR TITLE
Add selective buffer release and Mat-to-file saving APIs

### DIFF
--- a/cpp/FOCV_Storage.cpp
+++ b/cpp/FOCV_Storage.cpp
@@ -20,3 +20,12 @@ void FOCV_Storage::clear(const std::set<std::string> &ids_to_keep) {
     }
   }
 }
+
+void FOCV_Storage::release(const std::set<std::string>& ids_to_release) {
+  for (const auto& id : ids_to_release) {
+    auto it = items.find(id);
+    if (it != items.end()) {
+      items.erase(it);
+    }
+  }
+}

--- a/cpp/FOCV_Storage.hpp
+++ b/cpp/FOCV_Storage.hpp
@@ -33,6 +33,7 @@ public:
     static std::string save(std::string key, T &item);
 
     static void clear(const std::set<std::string> &ids_to_keep);
+    static void release(const std::set<std::string> &ids_to_release);
 };
 
 template <typename T>

--- a/cpp/react-native-fast-opencv.cpp
+++ b/cpp/react-native-fast-opencv.cpp
@@ -272,6 +272,36 @@ jsi::Value OpenCVPlugin::get(jsi::Runtime& runtime, const jsi::PropNameID& propN
           FOCV_Storage::clear(ids_to_keep);
           return true;
       });
+  } else if (propName == "releaseBuffers") {
+      return jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "releaseBuffers"),
+          1,
+          [=](
+              jsi::Runtime& runtime,
+              const jsi::Value& thisValue,
+              const jsi::Value* arguments,
+              size_t count
+          ) -> jsi::Value {
+              std::set<std::string> ids_to_release;
+
+              if (count > 0 && arguments[0].isObject()) {
+                  auto array = arguments[0].asObject(runtime).asArray(runtime);
+                  auto length = array.length(runtime);
+
+                  for (size_t i = 0; i < length; i++) {
+                      auto id = array
+                          .getValueAtIndex(runtime, i)
+                          .asString(runtime)
+                          .utf8(runtime);
+                      ids_to_release.insert(id);
+                  }
+              }
+
+              FOCV_Storage::release(ids_to_release);
+              return jsi::Value(true);
+          }
+      );
   } else if (propName == "saveMatToFile") {
       return jsi::Function::createFromHostFunction(
           runtime, jsi::PropNameID::forAscii(runtime, "saveMatToFile"), 4,
@@ -342,6 +372,7 @@ std::vector<jsi::PropNameID> OpenCVPlugin::getPropertyNames(jsi::Runtime& runtim
     result.push_back(jsi::PropNameID::forAscii(runtime, "copyObjectFromVector"));
     result.push_back(jsi::PropNameID::forAscii(runtime, "invoke"));
     result.push_back(jsi::PropNameID::forAscii(runtime, "clearBuffers"));
+    result.push_back(jsi::PropNameID::forAscii(runtime, "releaseBuffers"));
     result.push_back(jsi::PropNameID::forAscii(runtime, "saveMatToFile"));
 
     return result;

--- a/docs/pages/apidetails.md
+++ b/docs/pages/apidetails.md
@@ -144,6 +144,14 @@ Clears stored objects from memory.
 clearBuffers(idsToKeep?: string[]): void;
 ```
 
+### Release Buffers
+
+Clears specified stored objects from memory.
+
+```js
+releaseBuffers(idsToRelease?: string[]): void;
+```
+
 ###  Buffer to Mat
 
 Creates an object of type Mat based on an array of Buffer Array.

--- a/docs/pages/apidetails.md
+++ b/docs/pages/apidetails.md
@@ -206,6 +206,19 @@ type BufferType = {
 };
 ```
 
+### Save Mat to file
+
+Saves a Mat to a file on disk as JPEG or PNG. Compression is calculated as a number 0-1 (for JPEG: 0=low quality, 1=high quality; for PNG: 0=no compression, 1=max compression).
+
+```js
+saveMatToFile(
+  mat: Mat,
+  path: string,
+  format: 'jpeg' | 'png',
+  compression: number
+): void;
+```
+
 ## Functions
 
 ### Invoke function

--- a/src/utils/UtilsFunctions.ts
+++ b/src/utils/UtilsFunctions.ts
@@ -67,6 +67,19 @@ export type UtilsFunctions = {
     channels: number;
     buffer: BufferType[T];
   };
+  /**
+   * Saves a Mat to a file on disk as JPEG or PNG.
+   * @param mat - the Mat to save
+   * @param path - full path including filename
+   * @param format - 'jpeg' or 'png'
+   * @param compression - number 0-1 (for JPEG: 0=low quality, 1=high quality; for PNG: 0=no compression, 1=max compression)
+   */
+  saveMatToFile(
+    mat: Mat,
+    path: string,
+    format: 'jpeg' | 'png',
+    compression: number
+  ): void;
 
   inpaint(src: Mat, mask: Mat, dst: Mat, radius: number, flag: unknown): void;
 };

--- a/src/utils/UtilsFunctions.ts
+++ b/src/utils/UtilsFunctions.ts
@@ -15,9 +15,13 @@ type ImportBufferType = Omit<BufferType, 'uint32'>;
 
 export type UtilsFunctions = {
   /**
-   * Clears any buffers that were allocate to back Mats on the native side.
+   * Clears any buffers that were allocated to Mats on the native side.
    */
   clearBuffers(idsToKeep?: string[]): void;
+  /**
+   * Releases specified buffers that were allocated to Mats on the native side.
+   */
+  releaseBuffers(idsToRelease?: string[]): void;
   /**
    * Converts a byte array to a Mat.
    *


### PR DESCRIPTION
This PR introduces two new native APIs that improve memory management and image output handling.

**New features:**

- Selective buffer release (`releaseBuffers`)
   Adds the ability to explicitly release specific native buffers by ID instead of clearing all stored buffers, enabling more fine-grained memory control in long-running or real-time workflows.

- Save Mat to file (`saveMatToFile`)
   Introduces a utility for saving Mats directly to disk as PNG or JPEG with configurable compression. The API ensures parent directories exist and includes full TypeScript definitions and documentation.