### PR TITLE
fix: guard frameBufferToMat/createFromBuffer against short input buffers

### DIFF
--- a/cpp/structures/mat/MatFactory.cpp
+++ b/cpp/structures/mat/MatFactory.cpp
@@ -83,6 +83,14 @@ jsi::Value MatFactory::get(jsi::Runtime& runtime, const jsi::PropNameID& propNam
            auto inputBuffer = mrousavy::getTypedArray(rt, std::move(input));
            auto vec = inputBuffer.toVector(rt);
 
+           // vec is byteLength-sized; a short input would send memcpy past the
+           // end of the heap allocation (SIGSEGV). Throw a catchable JS error.
+           size_t requiredBytes = (size_t)rows * (size_t)cols * (size_t)channels;
+           if (vec.size() < requiredBytes) {
+             throw std::runtime_error("Fast OpenCV Error: frameBufferToMat input buffer is " + std::to_string(vec.size()) +
+                                      " bytes, but " + std::to_string(requiredBytes) + " are required!");
+           }
+
            cv::Mat mat(rows, cols, type);
            memcpy(mat.data, vec.data(), (int)rows * (int)cols * (int)channels);
            return FOCV_JsiObject::wrap(rt, "mat", std::make_shared<cv::Mat>(mat));
@@ -147,6 +155,14 @@ jsi::Value MatFactory::get(jsi::Runtime& runtime, const jsi::PropNameID& propNam
 
            auto inputBuffer = mrousavy::getTypedArray(rt, std::move(input));
            auto vec = inputBuffer.toVector(rt);
+
+           // vec is byteLength-sized; a short input would send memcpy past the
+           // end of the heap allocation (SIGSEGV). Throw a catchable JS error.
+           size_t requiredBytes = (size_t)rows * (size_t)cols * (size_t)channels * (size_t)typeSize;
+           if (vec.size() < requiredBytes) {
+             throw std::runtime_error("Fast OpenCV Error: createFromBuffer input buffer is " + std::to_string(vec.size()) +
+                                      " bytes, but " + std::to_string(requiredBytes) + " are required!");
+           }
 
            cv::Mat mat(rows, cols, modeType);
            memcpy(mat.data, vec.data(), (int)rows * (int)cols * (int)channels * typeSize);


### PR DESCRIPTION
## What

`frameBufferToMat` and `createFromBuffer` `memcpy` `rows * cols * channels (* typeSize)` bytes out of the input TypedArray without checking the buffer's actual length. If the caller passes a buffer smaller than the requested Mat dimensions, the `memcpy` reads past the end of the heap allocation → hard `SIGSEGV`, not catchable from JS.

## Real-world impact

We hit this in production: a camera pixel-buffer producer under-reported its buffer size (4x too small for RGBA), and the resulting `createFromBuffer` call segfaulted in `libc.so` on users' devices instead of failing with an error we could catch and recover from.

## Fix

Validate the input length before the copy and throw a descriptive `std::runtime_error` (surfaced to JS as a catchable exception) naming the actual vs required byte counts:

```
Fast OpenCV Error: createFromBuffer input buffer is 1048576 bytes, but 4194304 are required!
```

Sizes are computed in `size_t` to avoid int overflow on large dimensions. Oversized buffers are still accepted (only the required prefix is copied), matching current behavior.

We've been running this as a patch-package fix in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)