### PR TITLE
fix: align TypeScript types with native bindings

### DIFF
--- a/cpp/structures/mat/MatDelegate.cpp
+++ b/cpp/structures/mat/MatDelegate.cpp
@@ -90,7 +90,7 @@ jsi::Value MatDelegate::get(jsi::Runtime& rt, const std::string& propName, const
       return jsi::Function::createFromHostFunction(
           rt, jsi::PropNameID::forAscii(rt, "saveToFile"), 3,
           [object](jsi::Runtime& runtime, const jsi::Value& thisVal, const jsi::Value* args, size_t count) -> jsi::Value {
-              if (count < 4) {
+              if (count < 3) {
                   throw std::runtime_error("saveToFile requires 3 arguments: path, format, compression");
               }
             

--- a/src/functions/ImageProcessing/ImageTransform.ts
+++ b/src/functions/ImageProcessing/ImageTransform.ts
@@ -3,7 +3,7 @@ import type { InterpolationFlags } from '../../constants/ImageTransform';
 import type {
   Mat,
   Point2f,
-  PointVector,
+  Point2fVector,
   Scalar,
   Size,
 } from '../../objects/Objects';
@@ -17,8 +17,8 @@ export type ImageTransform = {
    * @param solveMethod method passed to cv::solve (DecompTypes)
    */
   getPerspectiveTransform(
-    src: PointVector,
-    dst: PointVector,
+    src: Point2fVector,
+    dst: Point2fVector,
     solveMethod: DecompTypes
   ): Mat;
 

--- a/src/objects/Objects.ts
+++ b/src/objects/Objects.ts
@@ -57,12 +57,12 @@ export declare class Mat {
     channels: number;
     buffer: Float64Array;
   };
-  saveToFile(path: string): void;
+  saveToFile(path: string, format: 'jpeg' | 'png', compression: number): void;
 
   static create(
-    rows?: number,
-    cols?: number,
-    dataType?: DataTypes,
+    rows: number,
+    cols: number,
+    dataType: DataTypes,
     data?: number[]
   ): Mat;
   static createFromBase64(base64: string): Mat;


### PR DESCRIPTION
## Summary

Four places where the published TypeScript types disagree with the library's own native (C++/JSI) argument parsing. Each fix is verified against the repo's own native source on `main`; these were **not** runtime-tested on a device.

### 1. `Mat.create` — required params typed as optional (segfault)

- **Native:** `cpp/structures/mat/MatFactory.cpp:13-15` reads `args[0].asNumber()`, `args[1].asNumber()`, `args[2].asNumber()` unconditionally (the data argument is guarded by `count > 3` at line 21, but rows/cols/type are not).
- **Current TS:** `static create(rows?: number, cols?: number, dataType?: DataTypes, data?: number[])` in `src/objects/Objects.ts`.
- **Symptom:** the optional typing invites `Mat.create()` with fewer than 3 args, which reads non-existent JSI arguments and segfaults.
- **Fix:** make `rows`, `cols`, `dataType` required; keep `data?` optional.

### 2. `getPerspectiveTransform` — wrong vector type

- **Native:** `cpp/FOCV_Function.cpp:1221-1222` reads `args.asPoint2fVectorPtr(1)` / `asPoint2fVectorPtr(2)` for src and dst.
- **Current TS:** `src`/`dst` typed as `PointVector` in `src/functions/ImageProcessing/ImageTransform.ts`.
- **Symptom:** passing a `PointVector` throws `Argument is not a Point2fVector` at runtime.
- **Fix:** type `src`/`dst` as `Point2fVector` and update the type import.

### 3. `Mat.saveToFile` — missing params

- **Native:** `cpp/structures/mat/MatDelegate.cpp` reads `path = args[0]` (string, line 100), `format = args[1]` (string, must be `"jpeg"` or `"png"`, line 107), `compression = args[2]` (number 0..1, line 110).
- **Current TS:** `saveToFile(path: string): void` in `src/objects/Objects.ts`.
- **Symptom:** the type omits two required arguments, so type-checked calls pass only `path` and fail native validation.
- **Fix:** `saveToFile(path: string, format: 'jpeg' | 'png', compression: number): void`.

### 4. `saveToFile` native arg-count guard is off by one

- **Native:** `cpp/structures/mat/MatDelegate.cpp:93` guards with `if (count < 4)` but the handler only reads `args[0..2]` (3 args).
- **Symptom:** a correct 3-argument call throws `saveToFile requires 3 arguments: path, format, compression`.
- **Fix:** change the guard to `if (count < 3)`.

## Verification

Verified against the repo's native source (not runtime-tested). `yarn typecheck` and `yarn lint` pass locally; the lefthook pre-commit hook (types, lint, commitlint) passed on commit.