### PR TITLE
feat: add fitEllipse and feature-tracking bindings, and support PointVectorOfVectors in drawing APIs

### DIFF
--- a/cpp/FOCV_Function.cpp
+++ b/cpp/FOCV_Function.cpp
@@ -1077,12 +1077,40 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
       } break;
       case hashString("goodFeaturesToTrack", 19): {
         auto image = args.asMatPtr(1);
-        auto corners = args.asMatPtr(2);
         auto maxCorners = args.asNumber(3);
         auto qualityLevel = args.asNumber(4);
         auto minDistance = args.asNumber(5);
-        
-        cv::goodFeaturesToTrack(*image, *corners, maxCorners, qualityLevel, minDistance);
+        auto blockSize = count > 6 ? args.asNumber(6) : 3;
+        auto useHarrisDetector = count > 7 ? args.asBool(7) : false;
+        auto k = count > 8 ? args.asNumber(8) : 0.04;
+
+        if (args.isPoint2fVector(2)) {
+          auto corners = args.asPoint2fVectorPtr(2);
+          cv::goodFeaturesToTrack(
+            *image,
+            *corners,
+            maxCorners,
+            qualityLevel,
+            minDistance,
+            cv::noArray(),
+            blockSize,
+            useHarrisDetector,
+            k
+          );
+        } else {
+          auto corners = args.asMatPtr(2);
+          cv::goodFeaturesToTrack(
+            *image,
+            *corners,
+            maxCorners,
+            qualityLevel,
+            minDistance,
+            cv::noArray(),
+            blockSize,
+            useHarrisDetector,
+            k
+          );
+        }
       } break;
       case hashString("HoughCircles", 12): {
         auto image = args.asMatPtr(1);
@@ -1710,9 +1738,61 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
         return FOCV_JsiObject::wrap(runtime, "mat", std::make_shared<cv::Mat>(H));
       } break;
 
+      case hashString("calcOpticalFlowPyrLK", 19): {
+        auto prevImg = args.asMatPtr(1);
+        auto nextImg = args.asMatPtr(2);
+        auto prevPts = args.asPoint2fVectorPtr(3);
+        auto nextPts = args.asPoint2fVectorPtr(4);
+        auto status = args.asMatPtr(5);
+        auto err = args.asMatPtr(6);
+        auto winSize = args.asSizePtr(7);
+        auto maxLevel = args.asNumber(8);
+        auto criteria = args.asTermCriteriaPtr(9);
+
+        cv::calcOpticalFlowPyrLK(
+          *prevImg,
+          *nextImg,
+          *prevPts,
+          *nextPts,
+          *status,
+          *err,
+          *winSize,
+          maxLevel,
+          *criteria
+        );
+      } break;
+
+      case hashString("estimateAffinePartial2D", 22): {
+        auto from = args.asPoint2fVectorPtr(1);
+        auto to = args.asPoint2fVectorPtr(2);
+        auto inliers = args.asMatPtr(3);
+        auto method = count > 4 ? static_cast<int>(args.asNumber(4)) : cv::RANSAC;
+        auto ransacReprojThreshold = count > 5 ? args.asNumber(5) : 3.0;
+        auto maxIters = count > 6 ? static_cast<size_t>(args.asNumber(6)) : 2000;
+        auto confidence = count > 7 ? args.asNumber(7) : 0.99;
+        auto refineIters = count > 8 ? static_cast<size_t>(args.asNumber(8)) : 10;
+
+        cv::Mat transform = cv::estimateAffinePartial2D(
+          *from,
+          *to,
+          *inliers,
+          method,
+          ransacReprojThreshold,
+          maxIters,
+          confidence,
+          refineIters
+        );
+
+        return FOCV_JsiObject::wrap(runtime, "mat", std::make_shared<cv::Mat>(transform));
+      } break;
+
       // ================== END FEATURE MATCHING FUNCTIONS ==================
     }
   } catch (cv::Exception& e) {
+    std::string message(e.what());
+    std::cout << "Fast OpenCV Invoke Error: " << message << "\n";
+    throw std::runtime_error("Fast OpenCV Error: " + message);
+  } catch (std::exception& e) {
     std::string message(e.what());
     std::cout << "Fast OpenCV Invoke Error: " << message << "\n";
     throw std::runtime_error("Fast OpenCV Error: " + message);

--- a/cpp/FOCV_Function.cpp
+++ b/cpp/FOCV_Function.cpp
@@ -953,13 +953,18 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
       } break;
       case hashString("drawContours", 12): {
         auto img = args.asMatPtr(1);
-        auto contours = args.asMatVectorPtr(2);
         auto contourIdx = args.asNumber(3);
         auto color = args.asScalarPtr(4);
         auto thickness = args.asNumber(5);
         auto line_type = args.asNumber(6);
-        
-        cv::drawContours(*img, *contours, contourIdx, *color, thickness, line_type);
+
+        if (args.isMatVector(2)) {
+          auto contours = args.asMatVectorPtr(2);
+          cv::drawContours(*img, *contours, contourIdx, *color, thickness, line_type);
+        } else {
+          auto contours = args.asPointVectorOfVectorsPtr(2);
+          cv::drawContours(*img, *contours, contourIdx, *color, thickness, line_type);
+        }
       } break;
       case hashString("drawMarker", 10): {
         auto img = args.asMatPtr(1);
@@ -1000,11 +1005,16 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
       } break;
       case hashString("fillPoly", 8): {
         auto img = args.asMatPtr(1);
-        auto pts = args.asMatVectorPtr(2);
         auto color = args.asScalarPtr(3);
         auto line_type = args.asNumber(4);
-        
-        cv::fillPoly(*img, *pts, *color, line_type);
+
+        if (args.isMatVector(2)) {
+          auto pts = args.asMatVectorPtr(2);
+          cv::fillPoly(*img, *pts, *color, line_type);
+        } else {
+          auto pts = args.asPointVectorOfVectorsPtr(2);
+          cv::fillPoly(*img, *pts, *color, line_type);
+        }
       } break;
       case hashString("line", 4): {
         auto img = args.asMatPtr(1);
@@ -1018,13 +1028,18 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
       } break;
       case hashString("polylines", 9): {
         auto img = args.asMatPtr(1);
-        auto pts = args.asMatVectorPtr(2);
         auto isClosed = args.asBool(3);
         auto color = args.asScalarPtr(4);
         auto thickness = args.asNumber(5);
         auto line_type = args.asNumber(6);
-        
-        cv::polylines(*img, *pts, isClosed, *color, thickness, line_type);
+
+        if (args.isMatVector(2)) {
+          auto pts = args.asMatVectorPtr(2);
+          cv::polylines(*img, *pts, isClosed, *color, thickness, line_type);
+        } else {
+          auto pts = args.asPointVectorOfVectorsPtr(2);
+          cv::polylines(*img, *pts, isClosed, *color, thickness, line_type);
+        }
       } break;
       case hashString("rectangle", 9): {
         auto img = args.asMatPtr(1);

--- a/cpp/FOCV_Function.cpp
+++ b/cpp/FOCV_Function.cpp
@@ -1494,6 +1494,17 @@ jsi::Object FOCV_Function::invoke(jsi::Runtime& runtime, const jsi::Value* argum
         }
         
       } break;
+      case hashString("fitEllipse", 10): {
+        cv::RotatedRect rect;
+
+        if (args.isMat(1)) {
+          rect = cv::fitEllipse(*args.asMatPtr(1));
+        } else {
+          rect = cv::fitEllipse(*args.asPointVectorPtr(1));
+        }
+
+        return FOCV_JsiObject::wrap(runtime, "rotated_rect", std::make_shared<cv::RotatedRect>(rect));
+      } break;
       case hashString("fitLine", 7): {
         auto points = args.asMatPtr(1);
         auto line = args.asMatPtr(2);

--- a/docs/content/apidetails.md
+++ b/docs/content/apidetails.md
@@ -234,11 +234,11 @@ Represents a rotated rectangle.
 
 **Properties:**
 - `type`: `ObjectType.RotatedRect`
-- `x`: `number`
-- `y`: `number`
-- `width`: `number`
-- `height`: `number`
-- `angle`: `number`
+- `x`: `number` - center x coordinate
+- `y`: `number` - center y coordinate
+- `width`: `number` - full width of the rotated rectangle
+- `height`: `number` - full height of the rotated rectangle
+- `angle`: `number` - rotation angle in degrees
 
 **Methods:**
 - `release(): void`

--- a/docs/content/availablefunctions.md
+++ b/docs/content/availablefunctions.md
@@ -1561,10 +1561,41 @@ Determines strong corners on an image
 
 ```js
 OpenCV.goodFeaturesToTrack(image: Mat,
-  corners: Mat,
+  corners: Mat | Point2fVector,
   maxCorners: number,
   qualityLevel: number,
-  minDistance: number
+  minDistance: number,
+  blockSize?: number,
+  useHarrisDetector?: boolean,
+  k?: number
+): void;
+```
+
+### calcOpticalFlowPyrLK
+
+Calculates an optical flow for a sparse feature set using the iterative Lucas-Kanade method with pyramids
+
+- name Function name.
+- prevImg First 8-bit input image
+- nextImg Second input image of the same size and type as prevImg
+- prevPts Vector of 2D points for which the flow needs to be found
+- nextPts Output vector of 2D points containing the calculated new positions of input features in the second image
+- status Output status vector (1 if the flow for the corresponding feature has been found, otherwise 0)
+- err Output vector of errors
+- winSize Size of the search window at each pyramid level
+- maxLevel 0-based maximal pyramid level number
+- criteria Parameter specifying the termination criteria of the iterative search algorithm
+
+```js
+OpenCV.calcOpticalFlowPyrLK(prevImg: Mat,
+  nextImg: Mat,
+  prevPts: Point2fVector,
+  nextPts: Point2fVector,
+  status: Mat,
+  err: Mat,
+  winSize: Size,
+  maxLevel: number,
+  criteria: TermCriteria
 ): void;
 ```
 
@@ -1749,6 +1780,34 @@ Returns the 3x3 perspective transform as a `Mat`.
 OpenCV.findHomographyFromMatches(
   srcPoints: Point2fVector,
   dstPoints: Point2fVector
+): Mat;
+```
+
+### estimateAffinePartial2D
+
+Computes an optimal limited affine transform (4 degrees of freedom) between two 2D point sets.
+
+- from First input 2D point set
+- to Second input 2D point set
+- inliers Output inlier mask
+- method Robust method (`cv::RANSAC` = 8 by default)
+- ransacReprojThreshold Maximum reprojection error in pixels for inliers
+- maxIters Maximum robust-method iterations
+- confidence Confidence level between 0 and 1
+- refineIters Maximum number of refinement iterations
+
+Returns a 2x3 affine transform `Mat`, or an empty `Mat` on failure.
+
+```js
+OpenCV.estimateAffinePartial2D(
+  from: Point2fVector,
+  to: Point2fVector,
+  inliers: Mat,
+  method?: number,
+  ransacReprojThreshold?: number,
+  maxIters?: number,
+  confidence?: number,
+  refineIters?: number
 ): Mat;
 ```
 

--- a/docs/content/availablefunctions.md
+++ b/docs/content/availablefunctions.md
@@ -2370,6 +2370,25 @@ OpenCV.findContoursWithHierarchy(image: Mat,
 ): void;
 ```
 
+### fitEllipse
+
+Fits an ellipse around a set of 2D points.
+
+- points Input 2D point set, stored in a Mat or PointVector. It should contain at least 5 points.
+@returns the rotated rectangle in which the ellipse is inscribed. In this library, `x` and `y` are the ellipse center coordinates, while `width` and `height` are the full axis lengths.
+
+```js
+OpenCV.fitEllipse(points: Mat | PointVector): RotatedRect;
+```
+
+```js
+const ellipse = OpenCV.fitEllipse(contour);
+
+console.log(ellipse.x, ellipse.y); // center
+console.log(ellipse.width, ellipse.height); // full axis lengths
+console.log(ellipse.angle); // degrees
+```
+
 ### fitLine
 
 Fits a line to a 2D or 3D point set.

--- a/docs/content/examples/_meta.js
+++ b/docs/content/examples/_meta.js
@@ -1,4 +1,5 @@
 export default {
   realtimedetection: 'Real-time detection',
   blur: 'Blur image on separated thread',
+  fitellipse: 'Fit ellipse to a contour',
 };

--- a/docs/content/examples/fitellipse.md
+++ b/docs/content/examples/fitellipse.md
@@ -1,0 +1,170 @@
+# Fit an ellipse to a contour
+
+This example shows the smallest useful `fitEllipse` flow in this repo: build a contour, fit the ellipse, draw the result, and inspect the returned `RotatedRect`.
+
+### Why this example uses synthetic points
+
+The goal here is to demonstrate the `fitEllipse` API itself, not contour extraction. A synthetic contour keeps the result deterministic and makes the returned geometry easy to verify.
+
+In real image-processing pipelines you would usually pass a contour returned by `findContours`.
+
+### Returned shape
+
+`OpenCV.fitEllipse(...)` returns a `RotatedRect` in this library:
+
+- `x`, `y` are the ellipse center coordinates
+- `width`, `height` are the full axis lengths
+- `angle` is the rotation angle in degrees
+
+When drawing that ellipse back with `OpenCV.ellipse(...)`, remember that the drawing API expects half-axis sizes, so the example divides `width` and `height` by `2`.
+
+### Code
+
+```js
+import { useState } from 'react';
+import { Button, Image, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  LineTypes,
+  Mat,
+  OpenCV,
+  Point,
+  PointVector,
+  Scalar,
+  Size,
+} from 'react-native-fast-opencv';
+
+const CANVAS_SIZE = 320;
+
+const samplePoints = [
+  [63, 177],
+  [76, 211],
+  [103, 239],
+  [143, 254],
+  [188, 251],
+  [227, 229],
+  [254, 193],
+  [264, 150],
+  [256, 108],
+  [228, 74],
+  [189, 53],
+  [144, 49],
+  [103, 65],
+  [75, 95],
+  [61, 136],
+];
+
+function buildEllipseExample() {
+  const background = new Uint8Array(CANVAS_SIZE * CANVAS_SIZE * 3).fill(255);
+  const image = Mat.createFromBuffer(
+    'uint8',
+    CANVAS_SIZE,
+    CANVAS_SIZE,
+    3,
+    background
+  );
+  const contour = PointVector.create();
+
+  for (const [x, y] of samplePoints) {
+    const point = Point.create(x, y);
+    contour.push(point);
+
+    OpenCV.circle(
+      image,
+      point,
+      4,
+      Scalar.create(70, 70, 70),
+      LineTypes.FILLED,
+      LineTypes.LINE_AA
+    );
+  }
+
+  const fittedEllipse = OpenCV.fitEllipse(contour);
+  const center = Point.create(
+    Math.round(fittedEllipse.x),
+    Math.round(fittedEllipse.y)
+  );
+  const axes = Size.create(
+    Math.round(fittedEllipse.width / 2),
+    Math.round(fittedEllipse.height / 2)
+  );
+
+  OpenCV.ellipse(
+    image,
+    center,
+    axes,
+    fittedEllipse.angle,
+    0,
+    360,
+    Scalar.create(40, 110, 255),
+    4,
+    LineTypes.LINE_AA
+  );
+
+  return {
+    image: image.toBase64(),
+    ellipse: fittedEllipse,
+  };
+}
+
+export function FitEllipseExample() {
+  const [example, setExample] = useState(() => buildEllipseExample());
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Button
+        title="Generate ellipse"
+        onPress={() => setExample(buildEllipseExample())}
+      />
+
+      {example.image ? (
+        <Image
+          source={{ uri: 'data:image/png;base64,' + example.image }}
+          style={styles.image}
+        />
+      ) : null}
+
+      {example.ellipse ? (
+        <View style={styles.values}>
+          <Text style={styles.heading}>RotatedRect result</Text>
+          <Text>x (center): {example.ellipse.x.toFixed(1)}</Text>
+          <Text>y (center): {example.ellipse.y.toFixed(1)}</Text>
+          <Text>width (full axis): {example.ellipse.width.toFixed(1)}</Text>
+          <Text>height (full axis): {example.ellipse.height.toFixed(1)}</Text>
+          <Text>angle: {example.ellipse.angle.toFixed(1)}</Text>
+        </View>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    gap: 16,
+    backgroundColor: 'white',
+  },
+  image: {
+    width: CANVAS_SIZE,
+    height: CANVAS_SIZE,
+    alignSelf: 'center',
+  },
+  values: {
+    gap: 4,
+  },
+  heading: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+});
+```
+
+### Using a real contour
+
+If you already have contours from `OpenCV.findContours(...)`, the core part becomes:
+
+```js
+const contour = contours.get(index);
+const ellipse = OpenCV.fitEllipse(contour);
+```
+
+Make sure the contour has at least 5 points before calling `fitEllipse`.

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,6 +6,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Home } from './home/Home';
 import { CameraPassthrough } from './examples/CameraPassthrough';
 import { DocumentDetection } from './examples/DocumentDetection';
+import { FitEllipseExample } from './examples/FitEllipseExample';
 
 const Stack = createNativeStackNavigator<StackParamList>();
 
@@ -23,6 +24,7 @@ export default function App() {
           name={Route.CameraPassthrough}
           component={CameraPassthrough}
         />
+        <Stack.Screen name={Route.FitEllipse} component={FitEllipseExample} />
         <Stack.Screen
           name={Route.CameraRealtimeDetection}
           component={CameraRealtimeDetection}

--- a/example/src/examples/FitEllipseExample.tsx
+++ b/example/src/examples/FitEllipseExample.tsx
@@ -1,0 +1,195 @@
+import { useState } from 'react';
+import {
+  Button,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import {
+  LineTypes,
+  Mat,
+  OpenCV,
+  Point,
+  PointVector,
+  Scalar,
+  Size,
+} from 'react-native-fast-opencv';
+
+const CANVAS_SIZE = 320;
+
+const samplePoints = [
+  [63, 177],
+  [76, 211],
+  [103, 239],
+  [143, 254],
+  [188, 251],
+  [227, 229],
+  [254, 193],
+  [264, 150],
+  [256, 108],
+  [228, 74],
+  [189, 53],
+  [144, 49],
+  [103, 65],
+  [75, 95],
+  [61, 136],
+] as const;
+
+interface EllipseInfo {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  angle: number;
+}
+
+interface ExampleState {
+  image: string;
+  ellipse: EllipseInfo;
+}
+
+function buildEllipseExample(): ExampleState {
+  const background = new Uint8Array(CANVAS_SIZE * CANVAS_SIZE * 3).fill(255);
+  const image = Mat.createFromBuffer(
+    'uint8',
+    CANVAS_SIZE,
+    CANVAS_SIZE,
+    3,
+    background
+  );
+  const contour = PointVector.create();
+
+  for (const [x, y] of samplePoints) {
+    const point = Point.create(x, y);
+    contour.push(point);
+
+    OpenCV.circle(
+      image,
+      point,
+      4,
+      Scalar.create(70, 70, 70),
+      LineTypes.FILLED,
+      LineTypes.LINE_AA
+    );
+  }
+
+  const fittedEllipse = OpenCV.fitEllipse(contour);
+
+  const center = Point.create(
+    Math.round(fittedEllipse.x),
+    Math.round(fittedEllipse.y)
+  );
+  const axes = Size.create(
+    Math.max(1, Math.round(fittedEllipse.width / 2)),
+    Math.max(1, Math.round(fittedEllipse.height / 2))
+  );
+
+  OpenCV.ellipse(
+    image,
+    center,
+    axes,
+    fittedEllipse.angle,
+    0,
+    360,
+    Scalar.create(40, 110, 255),
+    4,
+    LineTypes.LINE_AA
+  );
+  OpenCV.circle(
+    image,
+    center,
+    5,
+    Scalar.create(30, 30, 220),
+    LineTypes.FILLED,
+    LineTypes.LINE_AA
+  );
+
+  return {
+    image: image.toBase64(),
+    ellipse: {
+      x: fittedEllipse.x,
+      y: fittedEllipse.y,
+      width: fittedEllipse.width,
+      height: fittedEllipse.height,
+      angle: fittedEllipse.angle,
+    },
+  };
+}
+
+export function FitEllipseExample() {
+  const [example, setExample] = useState<ExampleState>(() =>
+    buildEllipseExample()
+  );
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Button
+        title="Generate ellipse"
+        onPress={() => setExample(buildEllipseExample())}
+      />
+
+      {example.image ? (
+        <Image
+          source={{ uri: 'data:image/png;base64,' + example.image }}
+          style={styles.image}
+        />
+      ) : null}
+
+      {example.ellipse ? (
+        <View style={styles.values}>
+          <Text style={styles.heading}>RotatedRect result</Text>
+          <Text style={styles.value}>
+            x (center): {example.ellipse.x.toFixed(1)}
+          </Text>
+          <Text style={styles.value}>
+            y (center): {example.ellipse.y.toFixed(1)}
+          </Text>
+          <Text style={styles.value}>
+            width (full axis): {example.ellipse.width.toFixed(1)}
+          </Text>
+          <Text style={styles.value}>
+            height (full axis): {example.ellipse.height.toFixed(1)}
+          </Text>
+          <Text style={styles.value}>
+            angle: {example.ellipse.angle.toFixed(1)}
+          </Text>
+        </View>
+      ) : null}
+
+      <Text style={styles.note}>
+        The drawn ellipse uses width / 2 and height / 2 because OpenCV.ellipse
+        expects half-axis sizes.
+      </Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    gap: 16,
+    backgroundColor: 'white',
+  },
+  image: {
+    width: CANVAS_SIZE,
+    height: CANVAS_SIZE,
+    alignSelf: 'center',
+  },
+  values: {
+    gap: 4,
+  },
+  heading: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: 'black',
+  },
+  value: {
+    color: 'black',
+  },
+  note: {
+    color: '#444',
+    lineHeight: 20,
+  },
+});

--- a/example/src/home/Home.tsx
+++ b/example/src/home/Home.tsx
@@ -18,6 +18,12 @@ const items: ItemDetails[] = [
     route: Route.ImageBlur,
   },
   {
+    title: 'Fit Ellipse',
+    emoji: '🟠',
+    description: 'Fit and draw an ellipse from contour points',
+    route: Route.FitEllipse,
+  },
+  {
     title: 'Camera Passthrough',
     emoji: '📷',
     description: 'Pass camera feed through',

--- a/example/src/types.ts
+++ b/example/src/types.ts
@@ -3,6 +3,7 @@ import type { ParamListBase } from '@react-navigation/native';
 export enum Route {
   Home = 'Home',
   ImageBlur = 'ImageBlur',
+  FitEllipse = 'FitEllipse',
   CameraPassthrough = 'CameraPassthrough',
   CameraRealtimeDetection = 'CameraRealtimeDetection',
   DocumentDetection = 'DocumentDetection',
@@ -11,6 +12,7 @@ export enum Route {
 export interface StackParamList extends ParamListBase {
   Home: undefined;
   ImageBlur: undefined;
+  FitEllipse: undefined;
   CameraPassthrough: undefined;
   CameraRealtimeDetection: undefined;
   DocumentDetection: undefined;

--- a/src/functions/ImageProcessing/Drawing.ts
+++ b/src/functions/ImageProcessing/Drawing.ts
@@ -4,6 +4,7 @@ import type {
   MatVector,
   Point,
   PointVector,
+  PointVectorOfVectors,
   Scalar,
   Size,
 } from '../../objects/Objects';
@@ -57,7 +58,7 @@ export type Drawing = {
    * Draws contours outlines or filled contours.
    * The function draws contour outlines in the image if 𝚝𝚑𝚒𝚌𝚔𝚗𝚎𝚜𝚜≥0 or fills the area bounded by the contours if 𝚝𝚑𝚒𝚌𝚔𝚗𝚎𝚜𝚜<0.
    * @param image Destination image.
-   * @param contours All the input contours. Each contour is stored as a point vector
+   * @param contours All the input contours. Accepts MatVector or PointVectorOfVectors, matching findContours
    * @param contourIdx Parameter indicating a contour to draw. If it is negative, all the contours are drawn.
    * @param color Color of the contours.
    * @param thickness Thickness of lines the contours are drawn with. If it is negative (for example, thickness=FILLED ), the contour interiors are drawn
@@ -65,7 +66,7 @@ export type Drawing = {
    */
   drawContours(
     image: Mat,
-    contours: MatVector,
+    contours: MatVector | PointVectorOfVectors,
     contourIdx: number,
     color: Scalar,
     thickness: number,
@@ -133,11 +134,16 @@ export type Drawing = {
   /**
    * Fills the area bounded by one or more polygons
    * @param img Image
-   * @param pts Array of polygons where each polygon is represented as an array of points
-   * @param color Polygon colo
+   * @param pts Array of polygons where each polygon is represented as an array of points. Accepts MatVector or PointVectorOfVectors
+   * @param color Polygon color
    * @param lineType Type of the polygon boundaries. See LineTypes
    */
-  fillPoly(img: Mat, pts: MatVector, color: Scalar, lineType: LineTypes): void;
+  fillPoly(
+    img: Mat,
+    pts: MatVector | PointVectorOfVectors,
+    color: Scalar,
+    lineType: LineTypes
+  ): void;
 
   /**
    * Draws a line segment connecting two points.
@@ -160,7 +166,7 @@ export type Drawing = {
   /**
    * Draws several polygonal curves
    * @param img Image
-   * @param pts Array of polygonal curves.
+   * @param pts Array of polygonal curves. Accepts MatVector or PointVectorOfVectors
    * @param isClosed Flag indicating whether the drawn polylines are closed or not. If they are closed, the function draws a line from the last vertex of each curve to its first vertex
    * @param color Polyline color
    * @param thickness Thickness of the polyline edges
@@ -168,7 +174,7 @@ export type Drawing = {
    */
   polylines(
     img: Mat,
-    pts: MatVector,
+    pts: MatVector | PointVectorOfVectors,
     isClosed: boolean,
     color: Scalar,
     thickness: number,

--- a/src/functions/ImageProcessing/Feature.ts
+++ b/src/functions/ImageProcessing/Feature.ts
@@ -1,5 +1,10 @@
 import type { HoughModes } from '../../constants/ImageProcessing';
-import type { Mat } from '../../objects/Objects';
+import type {
+  Mat,
+  Point2fVector,
+  Size,
+  TermCriteria,
+} from '../../objects/Objects';
 
 export type Feature = {
   /**
@@ -42,13 +47,43 @@ export type Feature = {
    * @param maxCorners Maximum number of corners to return. If there are more corners than are found, the strongest of them is returned. maxCorners <= 0 implies that no limit on the maximum is set and all detected corners are returned
    * @param qualityLevel Parameter characterizing the minimal accepted quality of image corners. The parameter value is multiplied by the best corner quality measure, which is the minimal eigenvalue (see cornerMinEigenVal ) or the Harris function response (see cornerHarris ). The corners with the quality measure less than the product are rejected. For example, if the best corner has the quality measure = 1500, and the qualityLevel=0.01 , then all the corners with the quality measure less than 15 are rejected.
    * @param minDistance Minimum possible Euclidean distance between the returned corners
+   * @param blockSize Size of an average block for computing a derivative covariation matrix over each pixel neighborhood. Default is 3
+   * @param useHarrisDetector Parameter indicating whether to use a Harris detector (see cornerHarris) or cornerMinEigenVal. Default is false
+   * @param k Free parameter of the Harris detector. Default is 0.04
    */
   goodFeaturesToTrack(
     image: Mat,
-    corners: Mat,
+    corners: Mat | Point2fVector,
     maxCorners: number,
     qualityLevel: number,
-    minDistance: number
+    minDistance: number,
+    blockSize?: number,
+    useHarrisDetector?: boolean,
+    k?: number
+  ): void;
+
+  /**
+   * Calculates an optical flow for a sparse feature set using the iterative Lucas-Kanade method with pyramids
+   * @param prevImg First 8-bit input image or pyramid constructed by buildOpticalFlowPyramid
+   * @param nextImg Second input image or pyramid of the same size and the same type as prevImg
+   * @param prevPts Vector of 2D points for which the flow needs to be found
+   * @param nextPts Output vector of 2D points containing the calculated new positions of input features in the second image
+   * @param status Output status vector (1 if the flow for the corresponding feature has been found, otherwise 0)
+   * @param err Output vector of errors; each element of the vector is set to an error for the corresponding feature
+   * @param winSize Size of the search window at each pyramid level
+   * @param maxLevel 0-based maximal pyramid level number
+   * @param criteria Parameter specifying the termination criteria of the iterative search algorithm
+   */
+  calcOpticalFlowPyrLK(
+    prevImg: Mat,
+    nextImg: Mat,
+    prevPts: Point2fVector,
+    nextPts: Point2fVector,
+    status: Mat,
+    err: Mat,
+    winSize: Size,
+    maxLevel: number,
+    criteria: TermCriteria
   ): void;
 
   /**

--- a/src/functions/ImageProcessing/FeatureMatching.ts
+++ b/src/functions/ImageProcessing/FeatureMatching.ts
@@ -97,4 +97,28 @@ export type FeatureMatching = {
     srcPoints: Point2fVector,
     dstPoints: Point2fVector
   ): Mat;
+
+  /**
+   * Computes an optimal limited affine transformation with 4 degrees of freedom
+   * between two 2D point sets using RANSAC (or another robust method).
+   * @param from First input 2D point set
+   * @param to Second input 2D point set of matching size and type as from
+   * @param inliers Output inlier mask; nonempty elements mark inliers
+   * @param method Robust method: RANSAC (default) or LMEDS
+   * @param ransacReprojThreshold Maximum reprojection error for a point to be treated as an inlier
+   * @param maxIters Maximum number of robust method iterations
+   * @param confidence Confidence level, between 0 and 1
+   * @param refineIters Maximum number of refinement iterations for refineIters > 0
+   * @returns The 2x3 affine transform matrix, or an empty Mat on failure
+   */
+  estimateAffinePartial2D(
+    from: Point2fVector,
+    to: Point2fVector,
+    inliers: Mat,
+    method?: number,
+    ransacReprojThreshold?: number,
+    maxIters?: number,
+    confidence?: number,
+    refineIters?: number
+  ): Mat;
 };

--- a/src/functions/ImageProcessing/Shape.ts
+++ b/src/functions/ImageProcessing/Shape.ts
@@ -126,6 +126,13 @@ export type Shape = {
   ): void;
 
   /**
+   * Fits an ellipse around a set of 2D points.
+   * @param points Input 2D point set, stored in a Mat or PointVector. It should contain at least 5 points.
+   * @returns the rotated rectangle in which the ellipse is inscribed
+   */
+  fitEllipse(points: Mat | PointVector): RotatedRect;
+
+  /**
    * Fits a line to a 2D or 3D point set.
    * @param points Input vector of 2D or 3D points, stored in a Mat.
    * @param line Output line parameters. In case of 2D fitting, it should be a vector of 4 elements (like Vec4f) - (vx, vy, x0, y0), where (vx, vy) is a normalized vector collinear to the line and (x0, y0) is a point on the line. In case of 3D fitting, it should be a vector of 6 elements (like Vec6f) - (vx, vy, vz, x0, y0, z0), where (vx, vy, vz) is a normalized vector collinear to the line and (x0, y0, z0) is a point on the line


### PR DESCRIPTION
## Summary

This PR adds a few OpenCV bindings and one drawing API fix:

- add `fitEllipse`
- add `calcOpticalFlowPyrLK`
- add `estimateAffinePartial2D`
- extend `goodFeaturesToTrack`
- support `PointVectorOfVectors` in `drawContours`, `fillPoly`, and `polylines`

## Why

These changes expose a few missing APIs that are useful for shape fitting and feature-tracking workflows, and fix drawing functions that currently do not accept nested point-vector inputs.

## Included

- native binding updates in `cpp/FOCV_Function.cpp`
- TS wrapper updates in the image-processing modules
- docs updates for the added functions
- a `fitEllipse` example in the example app

## Notes

The changes are intended to be additive and backward-compatible.

## Testing

- validated the new bindings in the example app
- verified the updated drawing functions accept `PointVectorOfVectors`